### PR TITLE
Remove deprecated field from build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,6 @@ javadoc {
 */
 
 task run(type:JavaExec) {
-   main = 'io.github.plotnik.bookindex'
+   mainClass = 'io.github.plotnik.bookindex'
    classpath = sourceSets.main.runtimeClasspath
 }


### PR DESCRIPTION
 Replacing deprecated `JavaExec.main` with `JavaExec.mainClass` in gradle build file.